### PR TITLE
[WIP] Integrate Prettier

### DIFF
--- a/lib/__snapshots__/semver.test.js.snap
+++ b/lib/__snapshots__/semver.test.js.snap
@@ -11,6 +11,11 @@ Object {
   },
   "extends": Array [
     "airbnb",
+    "prettier",
+    "prettier/react",
+  ],
+  "plugins": Array [
+    "prettier",
   ],
   "rules": Object {
     "arrow-body-style": Array [
@@ -93,6 +98,15 @@ Object {
       2,
       "methods",
     ],
+    "prettier/prettier": Array [
+      "error",
+      Object {
+        "printWidth": 80,
+        "singleQuote": true,
+        "tabWidth": 4,
+        "trailingComma": "all",
+      },
+    ],
     "react/forbid-prop-types": Array [
       2,
       Object {
@@ -133,6 +147,7 @@ Object {
 exports[`semver - should those tests break, consider releasing a new major version of the package dependencies 1`] = `
 Object {
   "eslint-config-airbnb": "^15.1.0",
+  "eslint-config-prettier": "^2.3.0",
 }
 `;
 
@@ -142,5 +157,6 @@ Object {
   "eslint-plugin-import": "^2.7.0",
   "eslint-plugin-jsx-a11y": "^5.1.1",
   "eslint-plugin-react": "^7.1.0",
+  "prettier": "~1.5.3",
 }
 `;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,17 @@
 // Specific linting rules for this file to simplify copy/pasting to JSON.
-/* eslint quotes: ["error", "double"], quote-props: ["error", "always"], comma-dangle: ["error", "never"], max-len: ["off"] */
+/* eslint quotes: ["error", "double"], quote-props: ["error", "always"], comma-dangle: ["error", "never"], max-len: ["off"], prettier: ["off"] */
 
+// prettier-ignore
 module.exports = {
     "extends": [
-        "airbnb"
+        "airbnb",
+        "prettier",
+        // "prettier/flowtype",
+        "prettier/react"
+    ],
+
+    "plugins": [
+        "prettier"
     ],
 
     "rules": {
@@ -40,7 +48,16 @@ module.exports = {
         "import/prefer-default-export": [0],
         // Does not work at the moment for nested fields.
         // https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md
-        "jsx-a11y/label-has-for": [0]
+        "jsx-a11y/label-has-for": [0],
+        // https://github.com/prettier/prettier#api
+        // As command-line flags:
+        // prettier --print-width 80 --tab-width 4 --single-quote --trailing-comma all
+        "prettier/prettier": ["error", {
+            "printWidth": 80,
+            "tabWidth": 4,
+            "singleQuote": true,
+            "trailingComma": "all"
+        }]
     },
 
     // http://eslint.org/docs/user-guide/configuring#specifying-environments

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-springload",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1070,6 +1070,14 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.3.0.tgz",
+      "integrity": "sha1-t1seq+oMi5ezRANkfuJds0m52KA=",
+      "requires": {
+        "get-stdin": "5.0.1"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
@@ -1534,6 +1542,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
     },
     "getpass": {
       "version": "0.1.7",
@@ -2971,6 +2984,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.5.3.tgz",
+      "integrity": "sha1-WdrcaDNF7GuI+IuU7Urn4do5S/4=",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -26,16 +26,19 @@
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-prettier": "^2.1.2",
     "eslint-plugin-react": "^7.1.0",
-    "jest": "^20.0.4"
+    "jest": "^20.0.4",
+    "prettier": "1.5.3"
   },
   "dependencies": {
-    "eslint-config-airbnb": "^15.1.0"
+    "eslint-config-airbnb": "^15.1.0",
+    "eslint-config-prettier": "^2.3.0"
   },
   "peerDependencies": {
     "eslint": "^3.19.0 || ^4.3.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-react": "^7.1.0"
+    "eslint-plugin-react": "^7.1.0",
+    "prettier": "~1.5.3"
   },
   "scripts": {
     "linter:js": "eslint",


### PR DESCRIPTION
Adds Prettier support within our linting configuration. There are a few intertwined blockers to resolve:

- For Prettier to be useful, it needs to be usable not just for linting but also as a formatting tool (ideally format on save in our editors). This means that we need access to the Prettier configuration when running Prettier standalone outside of ESLint, which breaks the encapsulation this package is meant to provide.
- Prettier doesn't support using configuration files instead of CLI flags, which means we would have to hard-code its config wherever it's used.
- Prettier is also reformatting JSON/CSS/SCSS among other languages/formats we use, but there is no way to change the configuration per-format or per-file. This is problematic, eg. we use 2 spaces as indentation for JSON and 4 for JS.

I think most of the above will be resolved in the next minor release, adding support for configuration files and configuration overrides (documented here: https://github.com/prettier/prettier/pull/2452). Then, we can:

- Create a configuration file within this package, using it from the config in `lib/index.js`, but also from outside of this package. This would look something like `prettier --config ./node_modules/eslint-config-springload/prettier.config.js`, or `prettier --config ./node_modules/eslint-plugin-springload/prettier.config.js` in most cases where the config is not used directly (the file will need to be created there as well and `require` the one from the config package).
- Take advantage of configuration overrides to enforce different rules on JSON, and potentially CSS/SCSS as well.

The only thing missing here is that I don't think there is a way to specify "use this other config file" from a local config in a project (config extends like what ESLint does), which means IDEs will need to replicate the configuration separately.

Once this is merged we will have to:

- [x] Update eslint-plugin-springload to leverage this as well
- [x] Update our pre-commit hooks to reformat staged JS(/JSON/CSS/SCSS) files. (https://github.com/prettier/prettier#option-3-bash-script)
- [ ] Figure out how best to configure our editors to do the formatting while writing the code directly.

There are a few more problems/opportunities I'm not too sure what to think of:

- I think package.json now supports arbitrary indentation, should we switch it back to 4 spaces?
- Should we use Prettier for CSS, SCSS?